### PR TITLE
Fixed iCheck for multiple pages

### DIFF
--- a/app/templates/admin_manageuser.html
+++ b/app/templates/admin_manageuser.html
@@ -74,13 +74,16 @@
 {% block extrascripts %}
 <script>
     // set up user data table
-    $("#tbl_users").DataTable({
-        "paging" : true,
-        "lengthChange" : false,
-        "searching" : true,
-        "ordering" : true,
-        "info" : true,
-        "autoWidth" : false
+    $(document).ready(function(){
+        var table = $('#tbl_users').DataTable({
+            'drawCallback': function(settings){
+            // iCheck for checkbox and radio inputs
+                $('input[type="checkbox"]').iCheck({
+                    checkboxClass: 'icheckbox_square-blue',
+                    increaseArea : '20%'
+                });
+            }
+        });
     });
     
     // handle revocation of privileges


### PR DESCRIPTION
iCheck (checkbox ) will now work on multiple pages. Document ready function will wait for all data to load, and then init the table. This way, checkbox's on pages 2, 3 ... are usable and saved.